### PR TITLE
Adding website guidelines checklist

### DIFF
--- a/howto/website-guidelines-checklist.md
+++ b/howto/website-guidelines-checklist.md
@@ -1,0 +1,32 @@
+# CNCF website guidelines checklist
+
+As per the [CNCF Website Guidelines](https://github.com/cncf/foundation/blob/master/website-guidelines.md), the following should be present:<br/>
+*Note*, not all of these are applicable to all projects
+
+- [ ] 1. Website should be [hosted in an open source repo](./repo-setup.md)
+  - [ ] Hosted in the same organization as the main project
+- [ ] 2. Reference the origin company correctly (if needed)<br/>
+    *Note*: It is OK to say that, e.g., “Prometheus was originally created by Soundcloud” or “Kubernetes builds upon 15 years of experience of running production workloads at Google,” but the origin company should not otherwise be referred to on the project homepage.
+- [ ] 3. No links or forms for capturing enterprise support leads should be present<br/>
+   *Note*: It is fine to have an enterprise support, commercial partners or similar page.
+  - [ ] If page is present, the companies list is alphabetized or randomized on load.
+  - [ ] If page is present, the vetting of companies listed is complete<br/>
+    *Note*: Projects are welcome to outsource this vetting to CNCF staff if it becomes a burden.
+- [ ] 4. Links to companies offering support go to a page that at least mentions support of the project
+- [ ] 5. Copyright notice present at bottom of page.<br/>
+   Copyright should be to the project authors or to CNCF, not the origin company. For details, see [Copyright notices](https://github.com/cncf/foundation/blob/master/copyright-notices.md).
+- [ ] 6. CNCF Branding elements
+  - [ ] “We are a Cloud Native Computing Foundation project.” or “We are a Cloud Native Computing Foundation sandbox project.” present (depending on status)  
+  - [ ] CNCF logo near the bottom of their project homepage
+  - [ ] *Optionally* link to KubeCon + CloudNativeCon as the events approach
+- [ ] 7. Page footer contents
+  - [ ] Trademark guidelines by either linking to Trademark Usage (directly or via a "Terms of service" page), or by including the following text:<br/>
+   "The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see [Trademark Usage](https://www.linuxfoundation.org/trademark-usage/)".
+
+## Community and license files 
+
+The following files should be in the root of the repository:
+
+- [ ] [CNCF Community Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
+- [ ] Guidelines for Contributors (CONTRIBUTING.md or similar)
+- [ ] [License file(s)](./repo-setup.md#license-files)


### PR DESCRIPTION
Creating a website guidelines checklist based on https://github.com/cncf/foundation/blob/master/website-guidelines.md & https://github.com/cncf/hugo-netlify-starter/pull/31

Deploy preview: https://github.com/cncf/techdocs/blob/23-release-checklist/howto/website-guidelines-checklist.md

With https://github.com/cncf/techdocs/pull/25 merged, this closes #23 