### PR TITLE
Update website-guidelines-checklist with DCO/CLA

### DIFF
--- a/howto/website-guidelines-checklist.md
+++ b/howto/website-guidelines-checklist.md
@@ -5,6 +5,8 @@ As per the [CNCF Website Guidelines](https://github.com/cncf/foundation/blob/mas
 
 - [ ] 1. Website should be [hosted in an open source repo](./repo-setup.md)
   - [ ] Hosted in the same organization as the main project
+  - [ ] Setup [DCO](https://github.com/apps/dco) or CLA (DCO recommended)  
+   CNCF's IP policy (https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy) requires all projects to use either CLA (Contributor License Agreements) or [DCO (Developer Certificate of Origin)](https://github.com/apps/dco). Unless there's a strong necessity to use CLA, we encourage projects to use DCO as it's easier to setup and use.
 - [ ] 2. Reference the origin company correctly (if needed)<br/>
     *Note*: It is OK to say that, e.g., “Prometheus was originally created by Soundcloud” or “Kubernetes builds upon 15 years of experience of running production workloads at Google,” but the origin company should not otherwise be referred to on the project homepage.
 - [ ] 3. No links or forms for capturing enterprise support leads should be present<br/>


### PR DESCRIPTION
Adding DCO/CLA check to Website line item.

Deploy preview: https://github.com/cncf/techdocs/blob/nw-dco-cla-check-2021-07-27/howto/website-guidelines-checklist.md