### PR TITLE
remove myself from README and remove outdated note

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -124,8 +124,6 @@ collaborators:
     permission: maintain
   - username: idvoretskyi
     permission: maintain
-  - username: kapunahelewong
-    permission: maintain
   - username: nate-double-u
     permission: maintain
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,10 @@ GitHub ID | Role
 [@celestehorgan](https://github.com/celestehorgan) | Senior technical writer
 [@chalin](https://github.com/chalin) | Senior technical writer
 [@nate-double-u](https://github.com/nate-double-u) | Dev advocate + tech writing
-[@kapunahelewong](https://github.com/kapunahelewong) | Dev advocate
 
 ## Office hours
 
 The CNCF tech docs team generally holds office hours on the [last Wednesday of every month at 10am Pacific time](https://www.cncf.io/calendar/) (1700 UTC).
-
-**Note:** December 2020 hours will be held on Wednesday, December 16 at 10am Pacific.
 
 Office hours started on 30 September, 2020.
 


### PR DESCRIPTION
Removes me from the readme and deletes note about meetings in the past. Though this isn't applicable until Friday, I'm submitting it now so it's here in case I forget!