### PR TITLE
adding "suggested doc" label

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -74,6 +74,9 @@ labels:
   - name: docs-assessment
     description: "CNCF TechDocs Assessments"
     color: c2e0c6
+  - name: suggested doc
+    description: "New doc suggestions for the docs/ section"
+    color: d93f0b
   # Default new repo labels
   - name: bug
     description: "Something isn't working"


### PR DESCRIPTION
adding "suggested doc" label for issues and PRs relating to creating a new document in the docs/ section of the repo.