### PR TITLE
add nate-double-u to admins

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -122,13 +122,13 @@ collaborators:
     permission: admin
   - username: caniszczyk
     permission: admin
+  - username: nate-double-u
+    permission: admin
 
   # Maintainers
   - username: chalin
     permission: maintain
   - username: idvoretskyi
-    permission: maintain
-  - username: nate-double-u
     permission: maintain
   - username: thisisobate
     permission: maintain


### PR DESCRIPTION
I'd like to make some changes to the cncf/techdocs repo settings to bring it in line with some of what we are doing over in the cncf/mentoring repo (things like branch protection, automatic merging when checks are satisfied, etc).