### PR TITLE
adding "admin" label

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -76,7 +76,10 @@ labels:
     color: c2e0c6
   - name: suggested doc
     description: "New doc suggestions for the docs/ section"
-    color: d93f0b
+    color: 89E295
+  - name: admin
+    description: "TechDocs administration activities"
+    color: 000000
   # Default new repo labels
   - name: bug
     description: "Something isn't working"


### PR DESCRIPTION
Contributes to https://github.com/cncf/techdocs/issues/154

adding "admin" label, updating "suggested doc" colour away from red hue