### PR TITLE
removing Collaborators from settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -112,30 +112,3 @@ labels:
     description: This issue has a related CNCF Service Desk ticket
     color: 0CD9EF
 
-# Collaborators: give specific users access to this repository.
-# See https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator for available options
-collaborators:
-    # Note: Only valid on organization-owned repositories.
-    # The permission to grant the collaborator. Can be one of:
-    # * `pull` - can pull, but not push to or administer this repository.
-    # * `push` - can pull and push, but not administer this repository.
-    # * `admin` - can pull, push and administer this repository.
-    # * `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
-    # * `triage` - Recommended for contributors who need to proactively manage issues and pull requests without write access.
-
-  # Administrators
-  - username: amye
-    permission: admin
-  - username: caniszczyk
-    permission: admin
-  - username: nate-double-u
-    permission: admin
-
-  # Maintainers
-  - username: chalin
-    permission: maintain
-  - username: idvoretskyi
-    permission: maintain
-  - username: thisisobate
-    permission: maintain
-


### PR DESCRIPTION
Removing Collaborators from settings.yml as repository access is now handled in the [/cncf/people](https://github.com/cncf/people/blob/main/config.yaml) repo.