### PR TITLE
Fix some reference links in the assessments/0009-in-toto directory

### DIFF
--- a/assessments/0009-in-toto/README.md
+++ b/assessments/0009-in-toto/README.md
@@ -20,7 +20,7 @@ This is an actionable plan for doc improvement, with specific implementation rec
 
 The analysis and recommendations for the in-toto project documentation are presented in these files: 
 
-- [Survey of existing documentation](./survey-of-existing-doc)  (as of September 2023)
+- [Survey of existing documentation](./survey-of-existing-doc.md)  (as of September 2023)
 - [Analysis](./in-toto-analysis.md)
 - [Recommendations and implementation](./in-toto-implementation.md)
 - [Proposed actionable issues](./in-toto-doc-issues.md)

--- a/assessments/0009-in-toto/in-toto-analysis.md
+++ b/assessments/0009-in-toto/in-toto-analysis.md
@@ -1,7 +1,7 @@
 # Analysis of Existing Documentation
 This document characterizes the effectiveness and completeness of the in-toto open source software (OSS) project's documentation and website as of September 2023. Documentation is analyzed with respect to CNCF criteria for completeness, discoverability, and usability.
 
-The analysis forms the basis for the recommendations and doc plan presented in the companion document, [(../in-toto-implementation.md)].
+The analysis forms the basis for the recommendations and doc plan presented in the companion [Implementation document](./in-toto-implementation.md).
 
 ## Scope of analysis
 The documentation discussed here includes the contents of the website at https://in-toto.io and https://in-toto.readthedocs.io/, the [in-toto Specification](https://github.com/in-toto/docs/tree/master/in-toto-spec.md), and the documentation for contributors and users in the various GitHub repositories at https://github.com/in-toto. See [Survey of existing documentation](./survey-of-existing-doc.md).


### PR DESCRIPTION
The file `assessments/0009-in-toto/README.md` contains a link **(Survey of existing documentation)** at the bottom that is broken. 
This is owing to the fact that the link doesn't contain the extension `.md` for the file it is referencing. 

This PR fixes that. It's a very small issue I observed.