### PR TITLE
Basic tooling: link & spell check, and formatting

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -1,0 +1,24 @@
+# cSpell:ignore textlintrc
+# For settings, see
+# https://www.streetsidesoftware.com/vscode-spell-checker/docs/configuration/
+version: '0.2'
+caseSensitive: true
+# ignorePaths:
+#   - '*.svg'
+# patterns:
+#   - name: CodeBlock
+#     pattern: |
+#       /
+#           ^(\s*[~`]{3,})   # code-block start
+#           .*               # all languages and options, e.g. shell {hl_lines=[12]}
+#           [\s\S]*?         # content
+#           \1               # code-block end
+#       /igmx # cspell:disable-line
+# languageSettings:
+#   - languageId: markdown
+#     ignoreRegExpList:
+#       - CodeBlock
+words:
+  - CNCF
+  - Docsy
+  - techdocs

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# npm assets
+node_modules/
+package-lock.json

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,10 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^http://localhost"
+    }
+  ],
+  "timeout": "3s",
+  "retryOn429": true,
+  "aliveStatusCodes": [200, 206]
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+.github
+
+# temporary
+
+assessments
+docs

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,9 +1,0 @@
-// For settings, see https://www.streetsidesoftware.com/vscode-spell-checker/docs/configuration/
-{
-    "version": "0.2",
-    "caseSensitive": true,
-    "words": [
-        "CNCF",
-        "Docsy"
-    ]
-}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "techdocs",
+  "version": "0.0.0",
+  "description": "Resources provided by the CNCF Technical Documentation team.",
+  "scripts": {
+    "_check:format:any": "npx prettier --check --ignore-path ''",
+    "_check:format": "npx prettier --check .",
+    "check:format": "npm run _check:format || (echo '[help] Run: npm run fix:format'; exit 1)",
+    "check:links": "npx markdown-link-check --config .markdown-link-check.json *.md",
+    "check:spelling": "npx cspell --no-progress -c .cspell.yml .",
+    "check": "npm run seq -- $(npm run -s _list:check:*)",
+    "fix:format": "npm run _check:format -- --write",
+    "fix": "npm run seq -- $(npm -s run _list:fix:*)",
+    "seq": "bash -c 'for cmd in \"$@\"; do npm run $cmd || exit 1; done' - ",
+    "test": "npm run check"
+  },
+  "author": "CNCF",
+  "license": "CC-BY-4.0",
+  "devDependencies": {
+    "cspell": "^8.8.1",
+    "markdown-link-check": "^3.12.1",
+    "prettier": "^3.2.5"
+  },
+  "private": true,
+  "prettier": {
+    "proseWrap": "always",
+    "singleQuote": true
+  }
+}


### PR DESCRIPTION
- Drops `.vscode`; moves the cSpell config to the top level
- Adds an NPM package with scripts to **check spelling, links, and formatting**, as well as fix formatting
  - Most files are ignored by the formatter at the moment. We can enable it over the main content once #229 is merged

/cc @dwelsch-esi