### PR TITLE
[notary-project] updated folder name in pathspec to fix link

### DIFF
--- a/assessments/0002-notary-project.md
+++ b/assessments/0002-notary-project.md
@@ -146,7 +146,7 @@ Is it possible plan documentation along side the V2 development? Will the docume
 - [ ] Setup Netlify for hosting/CI
 - [ ] Develop a [maintainers list](https://github.com/notaryproject/notaryproject.dev/blob/main/.github/settings.yml) for the documentation and its repository (this has been started https://github.com/notaryproject/notaryproject/issues/77)
 - [ ] Develop a maintenance plan for the documentation and its repository 
-- [ ] Follow the [CNCF website guidelines checklist](https://github.com/cncf/techdocs/blob/main/howto/website-guidelines-checklist.md) for other required elements
+- [ ] Follow the [CNCF website guidelines checklist](https://github.com/cncf/techdocs/blob/main/docs/website-guidelines-checklist.md) for other required elements
 
 _Note_: [Notary Project branding artwork](https://github.com/cncf/artwork/tree/master/projects/notary) exists. Other branding elements, like colour schemes and whatnot, will need to be developed.
 


### PR DESCRIPTION
`howto` was renamed to `docs` as part of https://github.com/cncf/techdocs/commit/b1b54b3a0b3de6ea9278104b796fcf1e794f9e21

There were a few pointer links hanging loose, this PR fixes the last of them.

https://github.com/cncf/techdocs/blob/main/howto/website-guidelines-checklist.md gives a `404`
Changed to https://github.com/cncf/techdocs/blob/main/docs/website-guidelines-checklist.md

Relative urls can be used, but I've left the absolute url coz the rest of the links were absolute.