### PR TITLE
Update NPM packages, and run Prettier

### DIFF
--- a/analyses/0006-gateway-api.md
+++ b/analyses/0006-gateway-api.md
@@ -261,7 +261,8 @@ The [website](https://gateway-api.sigs.k8s.io/) is accessible via HTTPS.
 
 - We can add a _Copyright_ notice present at bottom of the page. \
   Copyright should be to the project authors or to CNCF, not the origin company.
-  For details, see [Copyright notices](https://github.com/cncf/foundation/blob/master/copyright-notices.md).
+  For details, see
+  [Copyright notices](https://github.com/cncf/foundation/blob/master/copyright-notices.md).
 
 - CNCF Branding elements
 

--- a/analyses/0010-etcd/etcd-analysis.md
+++ b/analyses/0010-etcd/etcd-analysis.md
@@ -313,8 +313,8 @@ For example:
 - [installation check][install-check]: contains "sanity check", a term
   designated "Strongly Consider Replacing" by the [Inclusive Naming
   Initiative][inclusive-naming].
-- There is some use of language like "easy", "simple", and "just [take an
-  action]"; for example, "Creating a user is as easy as" in
+- There is some use of language like "easy", "simple", and "just [take
+  an action]"; for example, "Creating a user is as easy as" in
   [Role-based access control](https://etcd.io/docs/v3.5/op-guide/authentication/rbac/).
 
 ## Recommendations

--- a/docs/analysis/criteria.md
+++ b/docs/analysis/criteria.md
@@ -165,8 +165,7 @@ problems, keeping source files in two places:
 - makes it more complicated to generate the documentation from source files
 
 Ideally, all website files should be in the **website repo** itself.
-Alternatively, files should be brought into the website repo via [git
-submodules][].
+Alternatively, files should be brought into the website repo via [git submodules][].
 
 If a project chooses to keep source files in multiple repos, they need a clearly
 documented strategy for managing mirrored files and new contributions.
@@ -183,8 +182,8 @@ requirements for sandbox projects.
 - **Sandbox**
   - [Website guidelines](../website-guidelines-checklist.md): majority of the
     guidelines are satisfied
-  - [Docs assessment][]: consider [submitting a request][service desk] for an
-    assessment as early as possible to avoid documentation and website rework.
+  - [Docs assessment][]: consider [submitting a request][service desk] for an assessment
+    as early as possible to avoid documentation and website rework.
   - **Project documentation** may or may not be present -- it is acceptable at
     this maturity level to link out to documentation that hasn't yet been
     integrated into the website

--- a/docs/analysis/templates/analysis.md
+++ b/docs/analysis/templates/analysis.md
@@ -53,23 +53,23 @@ The documentation discussed here includes the entire contents of the website,
 the technical documentation, and documentation for contributors and users on the
 _PROJECT_ GitHub repository.
 
-The _PROJECT_ website and documentation are written in [Markdown, ReStructured
-Text, other] and are compiled using the [Hugo, Docusaurus, Sphynx, other] static
-site generator with the [Docsy, other] theme and served from [the Netlify
-platform, other]. The site's code is stored on the _PROJECT_ GitHub repo.
+The _PROJECT_ website and documentation are written in [Markdown,
+ReStructured Text, other] and are compiled using the [Hugo, Docusaurus,
+Sphynx, other] static site generator with the [Docsy, other] theme and served from
+[the Netlify platform, other]. The site's code is stored on the _PROJECT_ GitHub
+repo.
 
 **In scope:**
 
 - Website: _PROJECT-WEBSITE_
 - Documentation: _PROJECT-DOC-URL_
 - Website repo: _PROJECT-DOC-REPO_
-- _[Other; might include a demo server, governance site, or other relevant
-  repositories]_
+- _[Other; might include a demo server, governance site, or other relevant repositories]_
 
 **Out of scope:**
 
-- Other _PROJECT_ repos: _[In general, do not include sub-projects or related
-  "ecosystem" projects]_
+- Other _PROJECT_ repos: _[In general, do not include sub-projects or
+  related "ecosystem" projects]_
 
 ## How this document is organized
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -33,8 +33,8 @@ process below. Adapt it to your needs. Useful resources to consider include:
 In preparation for the migration, follow these steps:
 
 1.  **Create an issue** over your project's website with the title "Migrate to
-    Google Analytics 4 (GA4)", and link to [Issue #108][]. For example, see the
-    issues opened for the pilot projects listed in #108.
+    Google Analytics 4 (GA4)", and link to [Issue #108][]. For example, see the issues
+    opened for the pilot projects listed in #108.
 
 2.  Determine which **analytics library** your project's website is using.
 
@@ -69,8 +69,8 @@ Follow these steps:
 
     How you switch will depend on the static-site generation tooling you use.
     For details, see [Stage 2][]. If you know how to switch and it is easy to do
-    so, then switch your project to [gtag.js][], otherwise defer the switch to
-    [stage 2][].
+    so, then switch your project to [gtag.js][], otherwise defer the switch to [stage
+    2][].
 
 2.  **Open the analytics console** of your project's UA property by visiting
     [analytics.google.com](https://analytics.google.com).
@@ -179,9 +179,9 @@ code (such as custom Hugo partials) to enable GA4, consider removing the custom
 code in favor of the native support provided by your site-generator tooling.
 
 For example, for [Docsy][]-based websites, all you need to do is provide your
-project's GA4 measurement ID. Details are provided in [Adding Analytics][]. Of
-course, this may require you to upgrade the version of [Docsy][] and/or Hugo
-that your project is using.
+project's GA4 measurement ID. Details are provided in [Adding Analytics][]. Of course,
+this may require you to upgrade the version of [Docsy][] and/or Hugo that your project
+is using.
 
 [add gtag.js to your site]:
   https://developers.google.com/analytics/devguides/collection/gtagjs/

--- a/docs/website-guidelines-checklist.md
+++ b/docs/website-guidelines-checklist.md
@@ -8,11 +8,12 @@ all projects
 - [ ] 1. Website should be [hosted in an open source repo](./repo-setup.md)
   - [ ] Hosted in the same organization as the main project
   - [ ] Setup [DCO](https://github.com/apps/dco) or CLA (DCO recommended)  
-         CNCF's IP policy (https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy)
+         CNCF's IP policy
+        (https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy)
         requires all projects to use either CLA (Contributor License Agreements)
         or [DCO (Developer Certificate of Origin)](https://github.com/apps/dco).
-        Unless there's a strong necessity to use CLA, we encourage projects to use
-        DCO as it's easier to setup and use.
+        Unless there's a strong necessity to use CLA, we encourage projects to
+        use DCO as it's easier to setup and use.
 - [ ] 2. Reference the origin company correctly (if needed)<br/> _Note_: It is
      OK to say that, e.g., “Prometheus was originally created by Soundcloud” or
      “Kubernetes builds upon 15 years of experience of running production

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "author": "CNCF",
   "license": "CC-BY-4.0",
   "devDependencies": {
-    "cspell": "^8.8.1",
-    "markdown-link-check": "^3.12.1",
-    "prettier": "^3.2.5"
+    "cspell": "^8.8.4",
+    "markdown-link-check": "^3.12.2",
+    "prettier": "^3.3.1"
   },
   "private": true,
   "spelling": "cSpell:ignore loglevel -",


### PR DESCRIPTION
- Prettier 3.3 formats differently from earlier releases, so let's set that as a new minimum version.
- Updates all pkg version
- Updates pages after running Prettier 3.3.x