### PR TITLE
Removing Docs Assessment label

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -79,9 +79,6 @@ labels:
   - name: e4-months
     description: 'Effort: 1+ months'
     color: 996633
-  - name: Docs Assessment
-    description: 'CNCF TechDocs Assessments'
-    color: c2e0c6
   - name: Docs analysis
     description: CNCF technical documentation assistance
     color: c2e0c6


### PR DESCRIPTION
Follow up to https://github.com/cncf/techdocs/pull/249, contributes to https://github.com/cncf/techdocs/issues/247