### PR TITLE
Initialize Localization READMEs template

### DIFF
--- a/docs/localization/README.md
+++ b/docs/localization/README.md
@@ -11,3 +11,8 @@ Every guide here must meet the following requirements:
 - Meets the requirements of the original open-source license.
 
 Guides here must not violate copyright or licensing requirements.
+
+## Templates
+
+[TEMPLATE.md](TEMPLATE.md) is a template for creating new localization guides.
+You can copy this template and use it to create new guides.

--- a/docs/localization/TEMPLATE.md
+++ b/docs/localization/TEMPLATE.md
@@ -1,0 +1,82 @@
+# CNCF Localization Guidelines Template
+
+This document provides general guidelines to refer to when localizing CNCF
+projects.
+
+> [!IMPORTANT] These guidelines may not be applicable to all projects. Please
+> consult with the maintainers of each project, the community, or the lead for
+> localization as needed.
+
+## Table of Contents
+
+- [CNCF Localization Guidelines Template](#cncf-localization-guidelines-template)
+  - [Table of Contents](#table-of-contents)
+  - [Style Guide](#style-guide)
+  - [Specific Terms](#specific-terms)
+    - [Examples](#examples)
+  - [Review](#review)
+  - [Projects](#projects)
+  - [Communication](#communication)
+
+## Style Guide
+
+Please follow the "Localization Style Guide" relevant to your language and
+project.
+
+`<Put a link to the style guide here>`
+
+## Specific Terms
+
+For terms specific to CNCF projects, they should generally be left in English.
+However, if you need to provide translations for these terms or concepts on
+explanatory pages, please refer to the table below.
+
+| English                             | Translated               |
+| ----------------------------------- | ------------------------ |
+| Charter                             | `<put translation here>` |
+| Governing Board                     | ...                      |
+| SIG (Special Interest Group)        | ...                      |
+| TAB (Technical Advisory Board)      | ...                      |
+| TAG (Technical Advisory Group)      | ...                      |
+| TOC (Technical Oversight Committee) | ...                      |
+| WG (Working Group)                  | ...                      |
+| ...                                 | ...                      |
+
+### Examples
+
+| Recommended                          | Not Recommended                          |
+| ------------------------------------ | ---------------------------------------- |
+| `<put recommended translation here>` | `<put not recommended translation here>` |
+| ...                                  | ...                                      |
+
+## Review
+
+When creating a localization PR, request a review from the localization
+reviewers. Refer to the [Projects](#projects) table for reviewers in each
+repository. It is recommended to obtain approval from at least two localization
+reviewers.
+
+After obtaining approval from the localization reviewers, request the
+maintainers of each repository to merge the PR.
+
+## Projects
+
+This is a list of projects where localization is already in progress. When
+creating a localization PR, refer to the table below and notify the localization
+lead and reviewers as needed.
+
+| Project                                                           | Localization Lead      | Localization Reviewers |
+| ----------------------------------------------------------------- | ---------------------- | ---------------------- |
+| [CNCF Glossary](https://github.com/cncf/glossary)                 | `<put lead name here>` | `<put reviewers here>` |
+| [CNCF TAG App Delivery](https://github.com/cncf/tag-app-delivery) | ...                    | ...                    |
+| ...                                                               | ...                    | ...                    |
+
+## Communication
+
+Communication regarding localization of CNCF projects mainly takes place in the
+relevant channel on the [CNCF Slack](https://cloud-native.slack.com). If you have any
+questions or suggestions about localization, please discuss them in this
+channel, `<put channel name here>`.
+
+If you are not a member of the CNCF Slack, you can join via the
+[Community Inviter site](https://communityinviter.com/apps/cloud-native/cncf).


### PR DESCRIPTION
## Feature Descriptions

- Initialize Localization READMEs template


ref. https://github.com/cncf/techdocs/pull/259#issuecomment-2173954621
> I think it would be good to have an English version of this as well (even if it's very rough or just an outline). I'd like to use this work as a template or starting point for other languages. 