### PR TITLE
 Add trademark guidance for Series LLCs to website guidelines

### DIFF
--- a/docs/website-guidelines-checklist.md
+++ b/docs/website-guidelines-checklist.md
@@ -1,7 +1,7 @@
 # CNCF website guidelines checklist
 
 As per the
-[CNCF Website Guidelines](https://github.com/cncf/foundation/blob/master/website-guidelines.md),
+[CNCF Website Guidelines](https://github.com/cncf/foundation/blob/main/website-guidelines.md),
 the following should be present:<br/> _Note_, not all of these are applicable to
 all projects
 
@@ -37,12 +37,13 @@ all projects
         status)
   - [ ] CNCF logo near the bottom of their project homepage
   - [ ] _Optionally_ link to KubeCon + CloudNativeCon as the events approach
-- [ ] 7. Page footer contents
-  - [ ] Trademark guidelines by either linking to Trademark Usage (directly or
-        via a "Terms of service" page), or by including the following text:<br/>
-        "The Linux Foundation® (TLF) has registered trademarks and uses
-        trademarks. For a list of TLF trademarks, see
-        [Trademark Usage](https://www.linuxfoundation.org/trademark-usage/)".
+- [ ] 7. Website footers must include trademark guidelines by either linking to
+     [Trademark Usage][] (directly or via a "Terms of service" page), or by
+     including the following text: "The Linux Foundation® (TLF) has registered
+     trademarks and uses trademarks. For a list of TLF trademarks, see
+     [Trademark Usage][]". If your project has been converted to the Series LLC
+     model (starting in 2025), please use the following in your copyright
+     statement: "Copyright ©$PROJECT_NAME a Series of LF Projects, LLC."
 
 ## Community and license files
 
@@ -51,3 +52,5 @@ The following files should be in the root of the repository:
 - [ ] [CNCF Community Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
 - [ ] Guidelines for Contributors (CONTRIBUTING.md or similar)
 - [ ] [License file(s)](./repo-setup.md#license-files)
+
+[Trademark Usage]: https://www.linuxfoundation.org/trademark-usage/


### PR DESCRIPTION
* Follow up to https://github.com/cncf/foundation/pull/970
* Add the new guidance for Series LLC copyright footers. See the last item in https://github.com/cncf/foundation/issues/910
