### PR TITLE
Use slack.cncf.io as canonical URL

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,6 +1,9 @@
 {
   "ignorePatterns": [
     {
+      "pattern": "^https://slack.cncf.io/?"
+    },
+    {
       "pattern": "^http://localhost"
     },
     {

--- a/docs/localization/ja/README.md
+++ b/docs/localization/ja/README.md
@@ -70,4 +70,4 @@ CNCFのプロジェクト特有の用語については、原則として英語�
 
 CNCFのプロジェクトのローカライゼーションに関するコミュニケーションは、主に、[CNCFのSlack](https://cloud-native.slack.com)の[`#glossary-localization-japanese`](https://cloud-native.slack.com/archives/C057F81GFUG)チャンネルで行われています。ローカライゼーションに関する質問や提案がある場合は、こちらのチャンネルで議論してください。
 
-CNCFのSlackに参加していない場合は、[Community Inviterのサイト](https://communityinviter.com/apps/cloud-native/cncf)から参加できます。
+CNCFのSlackに参加していない場合は、[Community Inviterのサイト](https://slack.cncf.io)から参加できます。


### PR DESCRIPTION
- Link checking is failing atm because https://communityinviter.com/apps/cloud-native/cncf is down, see https://cloud-native.slack.com/archives/C014YQ8CDCG/p1742211006669909.
- Switches to using https://slack.cncf.io as a canonical URL
- Adds https://slack.cncf.io as an ignore pattern for the link checker