### PR TITLE
Adjust markdown syntax of analyses pages

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -11,6 +11,10 @@
     },
     {
       "pattern": "\\?no-link-check$"
+    },
+    {
+      "why": "Temporary: due to scheduled maintenance",
+      "pattern": "https://www.usenix.org"
     }
   ],
   "timeout": "3s",

--- a/analyses/0002-notary-project.md
+++ b/analyses/0002-notary-project.md
@@ -199,7 +199,7 @@ Criteria
   - Letting new users know where to get help
 
 - Complete the governance work started here:
-  <https://github.com/notaryproject/specifications/issues/55>
+  https://github.com/notaryproject/specifications/issues/55
   https://github.com/notaryproject/notaryproject/pull/78, and add it to a
   governance page (or section) on the website.
 

--- a/analyses/0005-fluxcd.md
+++ b/analyses/0005-fluxcd.md
@@ -5,7 +5,7 @@ cSpell:ignore: celestehorgan Horgan
 # Assessment template
 
 Prepared by: Celeste Horgan
-([@celestehorgan](https://github.com/cncf/techdocs))<br> Date: 2021-11-30
+([@celestehorgan](https://github.com/cncf/techdocs))<br/> Date: 2021-11-30
 
 ## Introduction
 
@@ -159,7 +159,7 @@ Scale:
 
 - [This file](https://github.com/fluxcd/website/blob/main/hack/import-flux2-assets.sh)
   is _very_ fragile, as it points to specific files at their
-  <https://github.com/fluxcd/website/blob/main/hack/import-flux2-assets.sh> and
+  https://github.com/fluxcd/website/blob/main/hack/import-flux2-assets.sh and
   seems to have the potential to make the site build succeed but with
   unpredictable results.
   - Consider implementing [Hugo Modules](https://gohugo.io/hugo-modules/) to

--- a/analyses/0006-gateway-api.md
+++ b/analyses/0006-gateway-api.md
@@ -5,7 +5,7 @@ cSpell:ignore: Meha Bhalodiya mehabhalodiya kubernetes
 # Assessment: Project Kubernetes Gateway API
 
 Prepared by: Meha Bhalodiya
-([@mehabhalodiya](https://github.com/mehabhalodiya))<br> Date: 2021-03-03
+([@mehabhalodiya](https://github.com/mehabhalodiya))<br/> Date: 2021-03-03
 
 ## Introduction
 

--- a/analyses/0007-porter.md
+++ b/analyses/0007-porter.md
@@ -16,11 +16,11 @@ Date: 2023-04-07
 Resources:
 
 - [Meeting notes](https://docs.google.com/document/d/12OGtSaUtlc7OA_iPnUvmVaiKg8yM7_QBzFnMgoHvnLw?no-link-check)
-- Website: <https://getporter.org>
+- Website: https://getporter.org
 - Repos:
-  - Main site: <https://github.com/getporter/porter>. Content is in `docs`.
+  - Main site: https://github.com/getporter/porter. Content is in `docs`.
   - [Operator site](https://getporter.org/operator):
-    <https://github.com/getporter/operator>
+    https://github.com/getporter/operator
 
 ## Introduction
 
@@ -69,8 +69,8 @@ Scale:
   difference between desired state and operator? maybe the operator one needs to
   be in Get Started)
 
-  - <https://getporter.org/quickstart/desired-state/>
-  - <https://getporter.org/operator/quickstart/>
+  - https://getporter.org/quickstart/desired-state/
+  - https://getporter.org/operator/quickstart/
 
 - Mixins & Plugins sections duplicated in sidebar (and could potentially be
   organized under Concepts?)
@@ -155,7 +155,7 @@ Scale:
 
 - Move the website sourcefile to a separate "website" directory. That way, we
   create a good separation of concern. A good example is
-  <https://github.com/thanos-io/thanos>.
+  https://github.com/thanos-io/thanos.
 - The porter's docs should be searchable.
 - Create a version picker (dropdown) to make search easily discoverable for
   users.

--- a/analyses/0008-backstage/README.md
+++ b/analyses/0008-backstage/README.md
@@ -1,6 +1,6 @@
 ---
 title: Backstage TechDocs Analysis
-tags: backstage
+tags: [backstage]
 ---
 
 - [Backstage Doc Analysis](backstage-analysis.md) - Analyzes the existing

--- a/analyses/0008-backstage/backstage-analysis.md
+++ b/analyses/0008-backstage/backstage-analysis.md
@@ -1,6 +1,6 @@
 ---
 title: Backstage Documentation Analysis
-tags: backstage
+tags: [backstage]
 created: 2023-09-01
 modified: 2023-11-28
 author: Dave Welsch (@dwelsch-esi)

--- a/analyses/0008-backstage/backstage-implementation.md
+++ b/analyses/0008-backstage/backstage-implementation.md
@@ -1,6 +1,6 @@
 ---
 title: Implementing Backstage Doc Improvements
-tags: backstage
+tags: [backstage]
 cSpell:ignore: rigeur runbooks toolkits
 ---
 

--- a/analyses/0009-in-toto/in-toto-implementation.md
+++ b/analyses/0009-in-toto/in-toto-implementation.md
@@ -89,9 +89,8 @@ following general plan.
    the website, as:
 
    - [System Overview](https://github.com/in-toto/docs/blob/master/in-toto-spec.md#2-system-overview)
-     (compare content to <https://in-toto.io/in-toto> and current website
-     About - create versions of increasing depth to address to specific
-     audiences)
+     (compare content to https://in-toto.io/in-toto and current website About -
+     create versions of increasing depth to address to specific audiences)
    - [Glossary](https://github.com/in-toto/docs/blob/master/in-toto-spec.md#17-terminology)
      (convert to alphabetized table)
    - [Workflow/Personas](https://github.com/in-toto/docs/blob/master/in-toto-spec.md#2-system-overview)

--- a/analyses/0010-etcd/README.md
+++ b/analyses/0010-etcd/README.md
@@ -1,6 +1,6 @@
 ---
 title: etcd TechDocs Analysis
-tags: etcd
+tags: [etcd]
 ---
 
 - [etcd Doc Analysis](etcd-analysis.md) - Analyzes the existing etcd

--- a/analyses/0010-etcd/etcd-analysis.md
+++ b/analyses/0010-etcd/etcd-analysis.md
@@ -1,6 +1,6 @@
 ---
 title: etcd Documentation Analysis
-tags: etcd
+tags: [etcd]
 created: 2023-09-01
 modified: 2024-01-08
 author: Dave Welsch (@dwelsch-esi)

--- a/analyses/0010-etcd/etcd-implementation.md
+++ b/analyses/0010-etcd/etcd-implementation.md
@@ -1,6 +1,6 @@
 ---
 title: Implementing etcd Doc Improvements
-tags: etcd
+tags: [etcd]
 ---
 
 # Introduction

--- a/analyses/0011-keda/README.md
+++ b/analyses/0011-keda/README.md
@@ -1,6 +1,6 @@
 ---
 title: KEDA TechDocs Analysis
-tags: KEDA
+tags: [KEDA]
 ---
 
 - [KEDA Doc Analysis](keda-analysis.md) - Analyzes the existing KEDA

--- a/analyses/0011-keda/keda-analysis.md
+++ b/analyses/0011-keda/keda-analysis.md
@@ -48,15 +48,15 @@ Netlify platform. The site's code is stored on the KEDA GitHub repo.
 
 **In scope:**
 
-- Website: <https://keda.sh>
-- Documentation: <https://keda.sh/docs>
-- Website repo: <https://github.com/kedacore/keda-docs>
-- Governance repo: <https://github.com/kedacore/governance>
-- Main project contributor info: <https://github.com/kedacore/keda>
+- Website: https://keda.sh
+- Documentation: https://keda.sh/docs
+- Website repo: https://github.com/kedacore/keda-docs
+- Governance repo: https://github.com/kedacore/governance
+- Main project contributor info: https://github.com/kedacore/keda
 
 **Out of scope:**
 
-- Other KEDA repos under <https://github.com/kedacore/>
+- Other KEDA repos under https://github.com/kedacore/
 
 ## How this document is organized
 
@@ -235,12 +235,12 @@ The documentation includes some examples of
 [**non-inclusive language**](https://inclusivenaming.org/). For example:
 
 - "easily", "simple", "simply", etc.
-  - <https://keda.sh/docs/2.13/deploy/>
-  - <https://keda.sh/docs/2.13/deploy/#uninstall-3>
-  - <https://keda.sh/docs/2.13/concepts/scaling-deployments/#triggers>
+  - https://keda.sh/docs/2.13/deploy/
+  - https://keda.sh/docs/2.13/deploy/#uninstall-3
+  - https://keda.sh/docs/2.13/concepts/scaling-deployments/#triggers
 - "master" node
-  - <https://keda.sh/docs/2.13/troubleshooting/#google-kubernetes-engine-gke>
-  - <https://keda.sh/docs/2.13/scalers/redis-sentinel-lists/#authentication-parameters>
+  - https://keda.sh/docs/2.13/troubleshooting/#google-kubernetes-engine-gke
+  - https://keda.sh/docs/2.13/scalers/redis-sentinel-lists/#authentication-parameters
 
 ## Recommendations
 

--- a/analyses/0011-keda/keda-implementation.md
+++ b/analyses/0011-keda/keda-implementation.md
@@ -77,7 +77,7 @@ Here is a proposed outline for the tech doc Table of Contents:
 - [Getting Started (New users start here!)](https://keda.sh/docs/2.13/) (rename
   current "KEDA Documentation" heading)
   - [Deploying KEDA](https://keda.sh/docs/2.13/deploy/)
-  - Prerequisites (<https://keda.sh/docs/2.13/operate/cluster/#requirements>)
+  - Prerequisites (https://keda.sh/docs/2.13/operate/cluster/#requirements)
   - [Deploying with Helm](?no-link-check#helm)
     - [Installing](?no-link-check#install)
     - [Uninstalling](?no-link-check#uninstall)
@@ -92,7 +92,7 @@ Here is a proposed outline for the tech doc Table of Contents:
     - [Uninstalling](?no-link-check#uninstall-3)
   - Hello, KEDA (write a procedure for a simplest-possible use case for users to
     get started on - something like
-    <https://github.com/kedacore/sample-hello-world-azure-functions>)
+    https://github.com/kedacore/sample-hello-world-azure-functions)
 - [Using KEDA or Operator Guide](https://keda.sh/docs/2.13/operate/) (rename
   current "Operate")
   - How to set up a scaler (a more detailed procedure than the example used in
@@ -103,13 +103,13 @@ Here is a proposed outline for the tech doc Table of Contents:
     - ... and so on.
   - [Admission Webhooks](https://keda.sh/docs/2.13/operate/admission-webhooks/)
   - Prevention Rules
-    (<https://keda.sh/docs/2.13/concepts/admission-webhooks/#prevention-rules>)
+    (https://keda.sh/docs/2.13/concepts/admission-webhooks/#prevention-rules)
   - Validation Enforcement
   - [Cluster](https://keda.sh/docs/2.13/operate/cluster/) - Except sections that
     are purely reference info, for example:
-  - <https://keda.sh/docs/2.13/operate/cluster/#kubernetes-compatibility>
-  - <https://keda.sh/docs/2.13/operate/cluster/#cluster-capacity>
-  - <https://keda.sh/docs/2.13/operate/cluster/#firewall>
+  - https://keda.sh/docs/2.13/operate/cluster/#kubernetes-compatibility
+  - https://keda.sh/docs/2.13/operate/cluster/#cluster-capacity
+  - https://keda.sh/docs/2.13/operate/cluster/#firewall
   - [Integrating with OpenTelemetry Collector (Experimental)](https://keda.sh/docs/2.13/integrations/opentelemetry/)
   - [Integrating with Prometheus](https://keda.sh/docs/2.13/integrations/prometheus/)
   - [Using the KEDA Metrics Server](https://keda.sh/docs/2.13/operate/metrics-server/)
@@ -119,11 +119,11 @@ Here is a proposed outline for the tech doc Table of Contents:
   - [Migrating to a new release](https://keda.sh/docs/2.13/migration/) (current
     "Migration Guide")
   - Caching Metrics
-    (<https://keda.sh/docs/2.13/concepts/scaling-deployments/#caching-metrics>)
+    (https://keda.sh/docs/2.13/concepts/scaling-deployments/#caching-metrics)
   - Pausing Autoscaling of deployments
-    (<https://keda.sh/docs/2.13/concepts/scaling-deployments/#pause-autoscaling>)
+    (https://keda.sh/docs/2.13/concepts/scaling-deployments/#pause-autoscaling)
   - Pausing Autoscaling of jobs
-    (<https://keda.sh/docs/2.13/concepts/scaling-jobs/#pause-autoscaling>)
+    (https://keda.sh/docs/2.13/concepts/scaling-jobs/#pause-autoscaling)
   - [Troubleshooting](https://keda.sh/docs/2.13/concepts/troubleshooting/),
     `/docs/2.13/troubleshooting/`
 - Reference
@@ -132,9 +132,9 @@ Here is a proposed outline for the tech doc Table of Contents:
     - ...
     - [Secret](https://keda.sh/docs/2.13/authentication-providers/secret/)
   - Scaled Object specification (from "Concepts";
-    <https://keda.sh/docs/2.13/concepts/scaling-deployments/#scaledobject-spec>)
+    https://keda.sh/docs/2.13/concepts/scaling-deployments/#scaledobject-spec)
   - ScaledJob specification
-    (<https://keda.sh/docs/2.13/concepts/scaling-jobs/#scaledjob-spec>)
+    (https://keda.sh/docs/2.13/concepts/scaling-jobs/#scaledjob-spec)
   - [Events](https://keda.sh/docs/2.13/operate/events/)
   - [Firewall requirements](https://keda.sh/docs/2.13/operate/cluster/#firewall)
   - ...
@@ -211,7 +211,7 @@ annotated to illustrate this point:
       - [Uninstalling](?no-link-check#uninstall-3)
   - Hello, KEDA (write a procedure for a simplest-possible use case for users to
     get started on - something like
-    <https://github.com/kedacore/sample-hello-world-azure-functions>) _analogous
+    https://github.com/kedacore/sample-hello-world-azure-functions) _analogous
     to a "Hello World" exercise in programming language or API guides_
 
 # Update the doc content creation instructions

--- a/analyses/0011-keda/keda-issues.md
+++ b/analyses/0011-keda/keda-issues.md
@@ -99,7 +99,7 @@ into multiple pages, one for each procedure.
       - [Uninstalling](?no-link-check#uninstall-3)
   - Hello, KEDA (write a procedure for a simplest-possible use case for users to
     get started on - something like
-    <https://github.com/kedacore/sample-hello-world-azure-functions>) _analogous
+    https://github.com/kedacore/sample-hello-world-azure-functions) _analogous
     to a "Hello World" exercise in programming language or API guides_
 
 ## Issue: Update the Operator Guide
@@ -111,9 +111,9 @@ Some guidelines:
 - Move "Troubleshooting" to the end of the Operator Guide.
 - Relocate sections that are purely reference information, including these
   sections in [Cluster](https://keda.sh/docs/2.13/operate/cluster/):
-  - <https://keda.sh/docs/2.13/operate/cluster/#kubernetes-compatibility>
-  - <https://keda.sh/docs/2.13/operate/cluster/#cluster-capacity>
-  - <https://keda.sh/docs/2.13/operate/cluster/#firewall>
+  - https://keda.sh/docs/2.13/operate/cluster/#kubernetes-compatibility
+  - https://keda.sh/docs/2.13/operate/cluster/#cluster-capacity
+  - https://keda.sh/docs/2.13/operate/cluster/#firewall
 - Break up long pages containing several topics. Aim for one major topic per
   page. For example, all HTTP-related headings on the
   [Cluster](https://keda.sh/docs/2.13/operate/cluster/) page could go on one
@@ -133,7 +133,7 @@ or provide a starting point.
     - ... and so on.
   - [Admission Webhooks](https://keda.sh/docs/2.13/operate/admission-webhooks/)
   - Prevention Rules
-    (<https://keda.sh/docs/2.13/concepts/admission-webhooks/#prevention-rules>)
+    (https://keda.sh/docs/2.13/concepts/admission-webhooks/#prevention-rules)
   - Validation Enforcement
   - [Cluster](https://keda.sh/docs/2.13/operate/cluster/) - (Relocate sections
     that are purely reference info)
@@ -151,11 +151,11 @@ or provide a starting point.
   - [Migrating to a new release](https://keda.sh/docs/2.13/migration/) (current
     "Migration Guide")
   - Caching Metrics
-    (<https://keda.sh/docs/2.13/concepts/scaling-deployments/#caching-metrics>)
+    (https://keda.sh/docs/2.13/concepts/scaling-deployments/#caching-metrics)
   - Pausing Autoscaling of deployments
-    (<https://keda.sh/docs/2.13/concepts/scaling-deployments/#pause-autoscaling>)
+    (https://keda.sh/docs/2.13/concepts/scaling-deployments/#pause-autoscaling)
   - Pausing Autoscaling of jobs
-    (<https://keda.sh/docs/2.13/concepts/scaling-jobs/#pause-autoscaling>)
+    (https://keda.sh/docs/2.13/concepts/scaling-jobs/#pause-autoscaling)
   - [Troubleshooting](https://keda.sh/docs/2.13/concepts/troubleshooting/)
     `/docs/2.13/troubleshooting/`
 
@@ -175,9 +175,9 @@ or provide a starting point.
     - ...
     - [Secret](https://keda.sh/docs/2.13/authentication-providers/secret/)
   - Scaled Object specification (from "Concepts";
-    <https://keda.sh/docs/2.13/concepts/scaling-deployments/#scaledobject-spec>)
+    https://keda.sh/docs/2.13/concepts/scaling-deployments/#scaledobject-spec)
   - ScaledJob specification
-    (<https://keda.sh/docs/2.13/concepts/scaling-jobs/#scaledjob-spec>)
+    (https://keda.sh/docs/2.13/concepts/scaling-jobs/#scaledjob-spec)
   - [Events](https://keda.sh/docs/2.13/operate/events/)
   - [Firewall requirements](https://keda.sh/docs/2.13/operate/cluster/#firewall)
   - ...
@@ -202,17 +202,17 @@ information. Some of these pages might appear in other issues suggesting that
 they be revised or relocated. If this creates contradictory recommendations,
 some judgement might be required to rearrange things.
 
-| Page Title                                             | URL                                                       | Notes                                                                                                                                                                                                                                                                           |
-| ------------------------------------------------------ | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Deploying KEDA                                         | <https://keda.sh/docs/2.13/deploy/>                       | Page is all install and uninstall tasks, but put each install procedure on its own page. Make this page an intro and index.                                                                                                                                                     |
-| Scaling Deployments, StatefulSets and Custom Resources | <https://keda.sh/docs/2.13/concepts/scaling-deployments/> | The "ScaledObject spec" is reference information. "Transfer ownership of an existing HPA" is a task.                                                                                                                                                                            |
-| Scaling Jobs                                           | <https://keda.sh/docs/2.13/concepts/scaling-jobs/>        | "ScaledJob spec" is reference information.                                                                                                                                                                                                                                      |
-| Authentication                                         | <https://keda.sh/docs/2.13/concepts/authentication/>      | Deliberately discuss the three patterns listed at the top of the page. This entire page might be better written as a task-based how-to guide.                                                                                                                                   |
-| External Scalers                                       | <https://keda.sh/docs/2.13/concepts/external-scalers/>    | "Implementing KEDA external scaler GRPC interface" is a series of tasks. The steps after the first 2 are choices -- Describe the task of downloading `externalscaler.proto` and preparing the project, then offer steps 3 - 6 as sub-tasks that can be performed independently. |
-| Troubleshooting                                        | <https://keda.sh/docs/2.13/concepts/troubleshooting/>     | Remove this troubleshooting information and combine it with the troubleshooting section under "The KEDA Documentation".                                                                                                                                                         |
-| Cluster                                                | <https://keda.sh/docs/2.13/operate/cluster/>              | See the "Update the Operator Guide" issue                                                                                                                                                                                                                                       |
-| Events                                                 | <https://keda.sh/docs/2.13/operate/events/>               | This is reference information.                                                                                                                                                                                                                                                  |
-| Integrate with Prometheus                              | <https://keda.sh/docs/2.13/integrations/prometheus/>      | Split this into a task ("Integrating with Prometheus" and a reference "Metrics Exported to Prometheus".                                                                                                                                                                         |
+| Page Title                                             | URL                                                     | Notes                                                                                                                                                                                                                                                                           |
+| ------------------------------------------------------ | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Deploying KEDA                                         | https://keda.sh/docs/2.13/deploy/                       | Page is all install and uninstall tasks, but put each install procedure on its own page. Make this page an intro and index.                                                                                                                                                     |
+| Scaling Deployments, StatefulSets and Custom Resources | https://keda.sh/docs/2.13/concepts/scaling-deployments/ | The "ScaledObject spec" is reference information. "Transfer ownership of an existing HPA" is a task.                                                                                                                                                                            |
+| Scaling Jobs                                           | https://keda.sh/docs/2.13/concepts/scaling-jobs/        | "ScaledJob spec" is reference information.                                                                                                                                                                                                                                      |
+| Authentication                                         | https://keda.sh/docs/2.13/concepts/authentication/      | Deliberately discuss the three patterns listed at the top of the page. This entire page might be better written as a task-based how-to guide.                                                                                                                                   |
+| External Scalers                                       | https://keda.sh/docs/2.13/concepts/external-scalers/    | "Implementing KEDA external scaler GRPC interface" is a series of tasks. The steps after the first 2 are choices -- Describe the task of downloading `externalscaler.proto` and preparing the project, then offer steps 3 - 6 as sub-tasks that can be performed independently. |
+| Troubleshooting                                        | https://keda.sh/docs/2.13/concepts/troubleshooting/     | Remove this troubleshooting information and combine it with the troubleshooting section under "The KEDA Documentation".                                                                                                                                                         |
+| Cluster                                                | https://keda.sh/docs/2.13/operate/cluster/              | See the "Update the Operator Guide" issue                                                                                                                                                                                                                                       |
+| Events                                                 | https://keda.sh/docs/2.13/operate/events/               | This is reference information.                                                                                                                                                                                                                                                  |
+| Integrate with Prometheus                              | https://keda.sh/docs/2.13/integrations/prometheus/      | Split this into a task ("Integrating with Prometheus" and a reference "Metrics Exported to Prometheus".                                                                                                                                                                         |
 
 # Write a Glossary
 

--- a/analyses/0012-TUF/analysis.md
+++ b/analyses/0012-TUF/analysis.md
@@ -1,6 +1,6 @@
 ---
 title: TUF Documentation Analysis
-tags: TUF
+tags: [TUF]
 created: 2024-06-17
 modified: YYYY-MM-DD
 author: Sandra Dindi (@Dindihub)
@@ -48,25 +48,24 @@ is stored on the TUF GitHub repo.
 
 #### In scope
 
-- Website and docs: <https://theupdateframework.io>
-- Website repo: <https://github.com/theupdateframework/theupdateframework.io>
-- The TUF community repository:
-  <https://github.com/theupdateframework/community>
+- Website and docs: https://theupdateframework.io
+- Website repo: https://github.com/theupdateframework/theupdateframework.io
+- The TUF community repository: https://github.com/theupdateframework/community
 - TUF specification repository:
-  <https://github.com/theupdateframework/specification>
-- TUF artwork repository: <https://github.com/theupdateframework/artwork>
+  https://github.com/theupdateframework/specification
+- TUF artwork repository: https://github.com/theupdateframework/artwork
 - Python reference implementation repository:
-  <https://github.com/theupdateframework/python-tuf>
+  https://github.com/theupdateframework/python-tuf
 
 #### Out of scope
 
 - TUF Augmentation proposals repository:
-  <https://github.com/theupdateframework/taps>
-- python-tuf: <https://theupdateframework.readthedocs.io>
-- go-tuf: <https://pkg.go.dev/github.com/theupdateframework/go-tuf>
+  https://github.com/theupdateframework/taps
+- python-tuf: https://theupdateframework.readthedocs.io
+- go-tuf: https://pkg.go.dev/github.com/theupdateframework/go-tuf
 - tuf-on-ci:
-  <https://github.com/theupdateframework/tuf-on-ci?tab=readme-ov-file#documentation>
-- RSTUF: <https://repository-service-tuf.readthedocs.io>
+  https://github.com/theupdateframework/tuf-on-ci?tab=readme-ov-file#documentation
+- RSTUF: https://repository-service-tuf.readthedocs.io
 
 ### How this document is organized
 

--- a/analyses/0012-TUF/issues.md
+++ b/analyses/0012-TUF/issues.md
@@ -7,9 +7,9 @@ cSpell:ignore: theupdateframework
 
 This issue tracks recommended changes resulting from an analysis of the TUF
 documentation commissioned by CNCF. The analysis and supporting documents are
-here: <https://github.com/cncf/techdocs/tree/main/analyses> under
-`0012-TUF`.This is a master list of issues recommended in the TUF tech doc
-analysis and implementation plan.
+here: https://github.com/cncf/techdocs/tree/main/analyses under `0012-TUF`.This
+is a master list of issues recommended in the TUF tech doc analysis and
+implementation plan.
 
 ## Issues
 

--- a/analyses/0013-litmuschaos/litmuschaos-analysis.md
+++ b/analyses/0013-litmuschaos/litmuschaos-analysis.md
@@ -1,6 +1,6 @@
 ---
 title: LitmusChaos Documentation Analysis
-tags: LitmusChaos
+tags: [LitmusChaos]
 created: 2024-08-02
 modified: 2024-10-09
 author: Dave Welsch (@dwelsch-esi)
@@ -54,17 +54,17 @@ GitHub repo.
 
 #### In scope
 
-- Website: <https://litmuschaos.io/>
-- Website repo: <https://github.com/litmuschaos/litmus-website-2>
-- Documentation repo: <https://github.com/litmuschaos/litmus-docs/>
+- Website: https://litmuschaos.io/
+- Website repo: https://github.com/litmuschaos/litmus-website-2
+- Documentation repo: https://github.com/litmuschaos/litmus-docs/
 - Main project repo (for governance and contributor docs):
-  <https://github.com/litmuschaos/litmus>
+  https://github.com/litmuschaos/litmus
 
 #### Out of scope
 
-- Other LitmusChaos repos: <https://github.com/litmuschaos/>
+- Other LitmusChaos repos: https://github.com/litmuschaos/
 - Litmus Software (a completely unrelated company and product based in
-  Massachusetts): <https://litmus.com/>
+  Massachusetts): https://litmus.com/
 
 ### How this document is organized
 
@@ -604,12 +604,12 @@ websites:
 
 <!-- markdownlint-disable line-length -->
 
-| Site                                                  | Repository                                                 | Tool or Stack            |
-| ----------------------------------------------------- | ---------------------------------------------------------- | ------------------------ |
-| [Project website](https://litmuschaos.io/)            | <https://github.com/litmuschaos/litmus-website-2>          | React/Next/Tailwind/SCSS |
-| [Documentation website](https://docs.litmuschaos.io/) | <https://github.com/litmuschaos/litmus-docs/>              | Docusaurus/Netlify       |
-| Tutorials                                             | <https://github.com/litmuschaos/tutorials>                 | Google Codelab?          |
-| [APIs][api-site]                                      | <https://github.com/litmuschaos/litmus/tree/master/mkdocs> | MkDocs                   |
+| Site                                                  | Repository                                               | Tool or Stack            |
+| ----------------------------------------------------- | -------------------------------------------------------- | ------------------------ |
+| [Project website](https://litmuschaos.io/)            | https://github.com/litmuschaos/litmus-website-2          | React/Next/Tailwind/SCSS |
+| [Documentation website](https://docs.litmuschaos.io/) | https://github.com/litmuschaos/litmus-docs/              | Docusaurus/Netlify       |
+| Tutorials                                             | https://github.com/litmuschaos/tutorials                 | Google Codelab?          |
+| [APIs][api-site]                                      | https://github.com/litmuschaos/litmus/tree/master/mkdocs | MkDocs                   |
 
 <!-- markdownlint-enable line-length -->
 

--- a/analyses/0013-litmuschaos/litmuschaos-implementation.md
+++ b/analyses/0013-litmuschaos/litmuschaos-implementation.md
@@ -1,6 +1,6 @@
 ---
 title: Implementing LitmusChaos Doc Improvements
-tags: LitmusChaos
+tags: [LitmusChaos]
 created: 2024-10-24
 author: Dave Welsch (@dwelsch-esi)
 cSpell:ignore: Welsch dwelsch

--- a/analyses/0013-litmuschaos/litmuschaos-issues.md
+++ b/analyses/0013-litmuschaos/litmuschaos-issues.md
@@ -38,20 +38,20 @@ websites.
 
 This issue tracks recommended changes resulting from an analysis of the Litmus
 Chaos documentation commissioned by CNCF. The analysis and supporting documents
-are here: <https://github.com/cncf/techdocs/tree/main/analyses> under
+are here: https://github.com/cncf/techdocs/tree/main/analyses under
 `0013-litmuschaos`.
 
 ### Possible Implementation
 
 The following repos are affected:
 
-| Repo URL                                             | Description                                     | Recommendation                                            |
-| ---------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
-| <https://github.com/litmuschaos/litmus-website-2>    | The project website repo                        | Combine with the doc repo                                 |
-| <https://github.com/litmuschaos/litmus-docs>         | Documentation repo                              | Combine with website repo                                 |
-| <https://github.com/litmuschaos/v1-litmus-docs>      | Another documentation repo, for docs before 2.0 | Move toward retiring and archiving.                       |
-| <https://github.com/litmuschaos/website-litmuschaos> | Previous website repo                           | Already archived. Include new repo URL in archive banner. |
-| <https://github.com/litmuschaos/tutorials>           | Tutorials repo                                  | Combine with documentation repo                           |
+| Repo URL                                           | Description                                     | Recommendation                                            |
+| -------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| https://github.com/litmuschaos/litmus-website-2    | The project website repo                        | Combine with the doc repo                                 |
+| https://github.com/litmuschaos/litmus-docs         | Documentation repo                              | Combine with website repo                                 |
+| https://github.com/litmuschaos/v1-litmus-docs      | Another documentation repo, for docs before 2.0 | Move toward retiring and archiving.                       |
+| https://github.com/litmuschaos/website-litmuschaos | Previous website repo                           | Already archived. Include new repo URL in archive banner. |
+| https://github.com/litmuschaos/tutorials           | Tutorials repo                                  | Combine with documentation repo                           |
 
 ## Issue: Removed obsolete websites
 
@@ -77,7 +77,7 @@ websites.
 
 This issue tracks recommended changes resulting from an analysis of the Litmus
 Chaos documentation commissioned by CNCF. The analysis and supporting documents
-are here: <https://github.com/cncf/techdocs/tree/main/analyses> under
+are here: https://github.com/cncf/techdocs/tree/main/analyses under
 `0013-litmuschaos`.
 
 ### Possible Implementation
@@ -85,10 +85,10 @@ are here: <https://github.com/cncf/techdocs/tree/main/analyses> under
 **GraphicQL API**
 
 The following API is one of the first hits on a search of "Litmus Chaos API":
-<https://litmuschaos.github.io/litmus/graphql/v2.0.0/api.html>.
+https://litmuschaos.github.io/litmus/graphql/v2.0.0/api.html.
 
 I'm not even sure where the doc repo is (it might be in the API's repo at
-<https://github.com/litmuschaos/spectaql>). It's clear this is a Litmus Chaos
+https://github.com/litmuschaos/spectaql). It's clear this is a Litmus Chaos
 component, but not whether this documentation is current or what it is for --
 there's no introduction or explanation of the API.
 
@@ -143,7 +143,7 @@ This issue concerns instructional information.
 
 This issue tracks recommended changes resulting from an analysis of the Litmus
 Chaos documentation commissioned by CNCF. The analysis and supporting documents
-are here: <https://github.com/cncf/techdocs/tree/main/analyses> under
+are here: https://github.com/cncf/techdocs/tree/main/analyses under
 `0013-litmuschaos`.
 
 ### Possible Implementation
@@ -224,7 +224,7 @@ This issue concerns instructional information.
 
 This issue tracks recommended changes resulting from an analysis of the Litmus
 Chaos documentation commissioned by CNCF. The analysis and supporting documents
-are here: <https://github.com/cncf/techdocs/tree/main/analyses> under
+are here: https://github.com/cncf/techdocs/tree/main/analyses under
 `0013-litmuschaos`.
 
 ### Possible Implementation
@@ -277,7 +277,7 @@ This issue concerns conceptual information.
 
 This issue tracks recommended changes resulting from an analysis of the Litmus
 Chaos documentation commissioned by CNCF. The analysis and supporting documents
-are here: <https://github.com/cncf/techdocs/tree/main/analyses> under
+are here: https://github.com/cncf/techdocs/tree/main/analyses under
 `0013-litmuschaos`.
 
 ### Possible Implementation
@@ -315,7 +315,7 @@ This issue concerns organizing all documentation information.
 
 This issue tracks recommended changes resulting from an analysis of the Litmus
 Chaos documentation commissioned by CNCF. The analysis and supporting documents
-are here: <https://github.com/cncf/techdocs/tree/main/analyses> under
+are here: https://github.com/cncf/techdocs/tree/main/analyses under
 `0013-litmuschaos`.
 
 ### Possible Implementation
@@ -376,7 +376,7 @@ This issue concerns instructional information.
 
 This issue tracks recommended changes resulting from an analysis of the Litmus
 Chaos documentation commissioned by CNCF. The analysis and supporting documents
-are here: <https://github.com/cncf/techdocs/tree/main/analyses> under
+are here: https://github.com/cncf/techdocs/tree/main/analyses under
 `0013-litmuschaos`.
 
 ### Possible Implementation
@@ -421,7 +421,7 @@ This issue concerns conceptual information.
 
 This issue tracks recommended changes resulting from an analysis of the Litmus
 Chaos documentation commissioned by CNCF. The analysis and supporting documents
-are here: <https://github.com/cncf/techdocs/tree/main/analyses> under
+are here: https://github.com/cncf/techdocs/tree/main/analyses under
 `0013-litmuschaos`.
 
 ### Possible Implementation
@@ -458,7 +458,7 @@ This issue concerns meta-information (project community resources).
 
 This issue tracks recommended changes resulting from an analysis of the Litmus
 Chaos documentation commissioned by CNCF. The analysis and supporting documents
-are here: <https://github.com/cncf/techdocs/tree/main/analyses> under
+are here: https://github.com/cncf/techdocs/tree/main/analyses under
 `0013-litmuschaos`.
 
 ### Possible Implementation
@@ -521,7 +521,7 @@ here. Some guidelines for writing procedures:
 
 This issue tracks recommended changes resulting from an analysis of the Litmus
 Chaos documentation commissioned by CNCF. The analysis and supporting documents
-are here: <https://github.com/cncf/techdocs/tree/main/analyses> under
+are here: https://github.com/cncf/techdocs/tree/main/analyses under
 `0013-litmuschaos`.
 
 ### Possible Implementation
@@ -561,7 +561,7 @@ question.
 
 This issue tracks recommended changes resulting from an analysis of the Litmus
 Chaos documentation commissioned by CNCF. The analysis and supporting documents
-are here: <https://github.com/cncf/techdocs/tree/main/analyses> under
+are here: https://github.com/cncf/techdocs/tree/main/analyses under
 `0013-litmuschaos`.
 
 ### Possible Implementation
@@ -592,7 +592,7 @@ This issue concerns potentially all types of information.
 
 This issue tracks recommended changes resulting from an analysis of the Litmus
 Chaos documentation commissioned by CNCF. The analysis and supporting documents
-are here: <https://github.com/cncf/techdocs/tree/main/analyses> under
+are here: https://github.com/cncf/techdocs/tree/main/analyses under
 `0013-litmuschaos`.
 
 ### Possible Implementation
@@ -600,19 +600,19 @@ are here: <https://github.com/cncf/techdocs/tree/main/analyses> under
 Here's a list of all the blog posts. Each should be evaluated for technical
 documentation content.
 
-- <https://litmuschaos.io/blog/litmuschaos-is-joining-kubecon-cloudnativecon-north-america-2024-3blg>
-- <https://litmuschaos.io/blog/introduction-to-k6-load-chaos-in-litmuschaos-4l2k>
-- <https://litmuschaos.io/blog/introduction-to-http-chaos-in-litmuschaos-3hn>
-- <https://litmuschaos.io/blog/gcp-iam-integration-for-litmuschaos-with-workload-identity-2eai>
-- <https://litmuschaos.io/blog/frontend-optimization-at-litmuschaos-1p14>
-- <https://litmuschaos.io/blog/litmuschaos-in-2021-the-year-in-review-38cl>
-- <https://litmuschaos.io/blog/how-to-contribute-blog-posts-for-litmuschaos-3cnp>
-- <https://litmuschaos.io/blog/getting-started-with-litmus-2-0-in-google-kubernetes-engine-4obf>
-- <https://litmuschaos.io/blog/part-2-a-beginner-s-practical-guide-to-containerisation-and-chaos-engineering-with-litmuschaos-2-0-253i>
-- <https://litmuschaos.io/blog/part-1-a-beginner-s-practical-guide-to-containerisation-and-chaos-engineering-with-litmuschaos-2-0-3h5c>
-- <https://litmuschaos.io/blog/litmuschaos-node-memory-hog-experiment-2nj6>
-- <https://litmuschaos.io/blog/analysing-chaos-workflows-with-litmus-portal-4e67>
-- <https://litmuschaos.io/blog/chaos-engineering-with-litmus-portal-on-okteto-cloud-3g57>
-- <https://litmuschaos.io/blog/how-to-use-react-hooks-in-apollo-client-for-graphql-33bh>
-- <https://litmuschaos.io/blog/declarative-approach-to-chaos-hypothesis-using-litmus-probes-5157>
-- <https://litmuschaos.io/blog/litmuschaos-gitlab-remote-templates-6l2>
+- https://litmuschaos.io/blog/litmuschaos-is-joining-kubecon-cloudnativecon-north-america-2024-3blg
+- https://litmuschaos.io/blog/introduction-to-k6-load-chaos-in-litmuschaos-4l2k
+- https://litmuschaos.io/blog/introduction-to-http-chaos-in-litmuschaos-3hn
+- https://litmuschaos.io/blog/gcp-iam-integration-for-litmuschaos-with-workload-identity-2eai
+- https://litmuschaos.io/blog/frontend-optimization-at-litmuschaos-1p14
+- https://litmuschaos.io/blog/litmuschaos-in-2021-the-year-in-review-38cl
+- https://litmuschaos.io/blog/how-to-contribute-blog-posts-for-litmuschaos-3cnp
+- https://litmuschaos.io/blog/getting-started-with-litmus-2-0-in-google-kubernetes-engine-4obf
+- https://litmuschaos.io/blog/part-2-a-beginner-s-practical-guide-to-containerisation-and-chaos-engineering-with-litmuschaos-2-0-253i
+- https://litmuschaos.io/blog/part-1-a-beginner-s-practical-guide-to-containerisation-and-chaos-engineering-with-litmuschaos-2-0-3h5c
+- https://litmuschaos.io/blog/litmuschaos-node-memory-hog-experiment-2nj6
+- https://litmuschaos.io/blog/analysing-chaos-workflows-with-litmus-portal-4e67
+- https://litmuschaos.io/blog/chaos-engineering-with-litmus-portal-on-okteto-cloud-3g57
+- https://litmuschaos.io/blog/how-to-use-react-hooks-in-apollo-client-for-graphql-33bh
+- https://litmuschaos.io/blog/declarative-approach-to-chaos-hypothesis-using-litmus-probes-5157
+- https://litmuschaos.io/blog/litmuschaos-gitlab-remote-templates-6l2


### PR DESCRIPTION
- Contributes to #54
- Adjusts the markdown syntax of `/analyses` pages, in preparation for publication using Docusaurus
- Adds ignore rule for https://www.usenix.org since the site is temporarily down