### PR TITLE
Add links to licenses to README and site footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ The full-time staff of the CNCF Tech Docs team is:
 
 Various consultants and volunteers also contribute to CNCF Tech Docs projects.
 
+## Licenses
+
+- Documentation: [CC-BY-4.0](LICENSE)
+- Code: [Apache-2.0](LICENSE-CODE)
+
 [date-time]:
   https://tockify.com/cncf.public.events/monthly?search=CNCF%20Tech%20Writers%20Office%20Hours
 [Zoom meeting 95471930872]:

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -66,6 +66,10 @@ const config: Config = {
       style: 'dark',
       links: [
         {
+          label: 'Licenses',
+          href: '/#licenses',
+        },
+        {
           label: 'Privacy',
           href: 'https://www.linuxfoundation.org/legal/privacy-policy',
         },


### PR DESCRIPTION
- Contributes to:
  - #54
  - #304 
- Followup to #305 
- Adds links to licenses to the README (and hence the site landing page), as well as the footer

**Preview**: https://deploy-preview-306--cncf-techdocs.netlify.app/#licenses