### PR TITLE
Link, title, and filename adjustments

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -5,7 +5,7 @@ version: '0.2'
 caseSensitive: true
 ignorePaths:
   - '*.csv'
-  - /docs/localization/ja
+  - /docs/[Ll]ocalization/ja # cSpell:disable-line
 # patterns:
 #   - name: CodeBlock
 #     pattern: |
@@ -20,7 +20,6 @@ ignorePaths:
 #     ignoreRegExpList:
 #       - CodeBlock
 words:
-  - nvmrc
   - backstore
   - CLOTributor
   - CNCF
@@ -29,9 +28,9 @@ words:
   - kedacore
   - krook
   - nate
+  - nvmrc
   - subpages
   - techdocs
   - toolkits
   - toto
   - triaging
-  - w.

--- a/docs/analysis/templates/analysis.md
+++ b/docs/analysis/templates/analysis.md
@@ -115,9 +115,9 @@ Readers interested in the current state of the documentation and the reasoning
 behind the recommendations should read the section of this document pertaining
 to their area of concern:
 
-- [Project documentation](?TODO=ADD-URL)
-- [Contributor documentation](?TODO=ADD-URL)
-- [Website and documentation infrastructure](?TODO=ADD-URL)
+- [Project documentation](./?TODO=ADD-URL)
+- [Contributor documentation](./?TODO=ADD-URL)
+- [Website and documentation infrastructure](./?TODO=ADD-URL)
 
 Examples of CNCF documentation that demonstrate the analysis criteria are linked
 from the [criteria] specification.
@@ -550,8 +550,8 @@ The numeric rating values used in this document are as follows
 [criteria]: ../criteria.md
 [implementation]: ./implementation.md
 [issues list]: ./issues-list.md
-[project-doc-website]: ?_PROJECT-DOC-URL_
-[project-website]: ?_PROJECT-WEBSITE_
+[project-doc-website]: ./?_PROJECT-DOC-URL_
+[project-website]: ./?_PROJECT-WEBSITE_
 [Rating (1-5)]: #rating-values
 [rfc-spec]: https://www.rfc-editor.org/rfc/rfc2119
 [website guidelines]: ../../website-guidelines-checklist.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,6 @@ sidebar_position: 1
 
 # CNCF Techdocs how-tos
 
-This directory contains documentation on how the CNCF TechDocs team does things.
+This section contains documentation on how the CNCF TechDocs team does things.
 While its intent is for the CNCF TechDocs team's use, we encourage project
-maintainers to use these documents if you find them helpful!
+maintainers to use these documents if you find them helpful.

--- a/docs/sandbox-doc-primer.md
+++ b/docs/sandbox-doc-primer.md
@@ -1,11 +1,13 @@
 ---
-title: CNCF sandbox project documentation primer
+title: CNCF sandbox-project docs primer
+sidebar:
+  label: Sandbox-project docs primer
 ---
 
-# CNCF sandbox project documentation primer
+# CNCF sandbox-project docs primer
 
-This document is a quick primer for CNCF project maintainers and contributors
-who need to document their projects but don't know where to start. It provides a
+This page is a quick primer for CNCF project maintainers and contributors who
+need to document their projects but don't know where to start. It provides a
 framework for thinking about user documentation that will enable the project
 contributors to write effective documentation from the very beginning and to get
 the most out of documentation efforts as the project matures.

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,8 +1,9 @@
 ---
-title: Documentation Search
+title: Site Search
+sidebar: { label: Search }
 ---
 
-# Documentation Search
+# Site Search
 
 <!-- markdownlint-disable no-duplicate-heading -->
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,10 +1,10 @@
 ---
-title: Doc Versioning with Hugo & Netlify
+title: Versioned docs with Hugo & Netlify
 # prettier-ignore
 cSpell:ignore: Batard Brubaker Pursley velero fullversion githubbranch docsbranch Tanzu Rosland Horgan Takahashi
 ---
 
-# Doc Versioning with Hugo & Netlify
+# Versioned docs with Hugo & Netlify
 
 Technical Documents Versioning is an intersection of:
 

--- a/docs/website-guidelines-checklist.md
+++ b/docs/website-guidelines-checklist.md
@@ -1,10 +1,10 @@
 ---
-title: CNCF website guidelines checklist
+title: Website guidelines & checklist
 ---
 
-# CNCF website guidelines checklist
+# Website guidelines & checklist
 
-As per the
+Per the
 [CNCF Website Guidelines](https://github.com/cncf/foundation/blob/main/website-guidelines.md),
 the following should be present:<br/> _Note_, not all of these are applicable to
 all projects


### PR DESCRIPTION
- Fixes "bogus" links in templates to have a non-empty path
- Adjusts titles and file base names so that the natural order of the how-to pages is alphabetical
- Does minor cleanup to cSpell config and word list
- Applies other minor copyedits