### PR TITLE
ci: declare least-privilege permissions in workflows

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -3,6 +3,9 @@ name: Format checks
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   format-check:
     name: FILE FORMAT

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -3,6 +3,9 @@ name: Link checks
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   link-check:
     name: LINK checking

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -3,6 +3,9 @@ name: Spelling checks
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   spelling-check:
     name: SPELLING check

--- a/.github/workflows/trigger-contribute-site-netlify.yml
+++ b/.github/workflows/trigger-contribute-site-netlify.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+# Only posts to NETLIFY_CONTRIBUTE_SITE_BUILD_HOOK; no GitHub API.
+permissions: {}
+
 jobs:
   trigger:
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger-contribute-site-netlify.yml
+++ b/.github/workflows/trigger-contribute-site-netlify.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
 
-# Only posts to NETLIFY_CONTRIBUTE_SITE_BUILD_HOOK; no GitHub API.
 permissions: {}
 
 jobs:


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` on the four workflows still inheriting org defaults:

- `format-check.yml`, `link-check.yml`, `spell-check.yml` — `contents: read`. PR-time read-only checks (`npm run check:format/markdown/links/spelling`).
- `trigger-contribute-site-netlify.yml` — `permissions: {}`. The job only POSTs to `NETLIFY_CONTRIBUTE_SITE_BUILD_HOOK`; no checkout, no GitHub API calls.

YAML validated locally.