### PR TITLE
[AIAA] Add assessment workflow labels and repair label sync in settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -49,79 +49,107 @@ repository:
 # Labels: define labels for Issues and Pull Requests
 labels:
   - name: admin
-    color: #d93f0b
-  - name: meta
-    description: Tracker issue
-    color: #0E8A16
+    description: 'TechDocs administration activities'
+    color: 'd93f0b'
   - name: CI/infra
     description: CI & infrastructure
-    color: #696969
+    color: '696969'
   - name: p0-critical
-    color: B60205
+    color: 'B60205'
   - name: p1-high
-    color: D93F0B
+    color: 'D93F0B'
   - name: p2-medium
-    color: FBCA04
+    color: 'FBCA04'
   - name: p3-low
-    color: FEF2C0
+    color: 'FEF2C0'
   - name: e0-minutes
     description: 'Effort: < 60 min'
-    color: e6ccb3
+    color: 'e6ccb3'
   - name: e1-hours
     description: 'Effort: < 8 hrs'
-    color: d9b38c
+    color: 'd9b38c'
   - name: e2-days
     description: 'Effort: < 5 days'
-    color: cc9966
+    color: 'cc9966'
   - name: e3-weeks
     description: 'Effort: < 4 weeks'
-    color: bf8040
+    color: 'bf8040'
   - name: e4-months
     description: 'Effort: 1+ months'
-    color: 996633
+    color: '996633'
   - name: Docs analysis
     description: CNCF technical documentation assistance
-    color: c2e0c6
+    color: 'c2e0c6'
   - name: Website Update
     description: 'CNCF Help request for project website updates'
-    color: BFAFE3
+    color: 'BFAFE3'
   - name: suggested doc
     description: 'New doc suggestions for the docs/ section'
-    color: 89E295
-  - name: admin
-    description: 'TechDocs administration activities'
-    color: 000000
+    color: 'd93f0b'
   # Default new repo labels
   - name: bug
     description: "Something isn't working"
-    color: d73a4a
+    color: 'd73a4a'
   - name: documentation
     description: Improvements or additions to the TechDocs documentation
-    color: 0075ca
+    color: '0075ca'
   - name: duplicate
     description: This issue or pull request already exists
-    color: cfd3d7
+    color: 'cfd3d7'
   - name: enhancement
     description: New feature or request
-    color: a2eeef
+    color: 'a2eeef'
   - name: good first issue
     description: Good for newcomers
-    color: 7057ff
+    color: '7057ff'
   - name: help wanted
     description: Extra attention is needed
-    color: 008672
+    color: '008672'
   - name: invalid
     description: "This doesn't seem right"
-    color: e4e669
+    color: 'e4e669'
   - name: question
     description: Further information is requested
-    color: d876e3
+    color: 'd876e3'
   - name: wontfix
     description: This will not be worked on
-    color: ffffff
+    color: 'ffffff'
   - name: ops/service-desk
     description: Service desk and support operations
-    color: 32CD32
+    color: '32CD32'
   - name: CNCF Service Desk
     description: This issue has a related CNCF Service Desk ticket
-    color: 0CD9EF
+    color: '0CD9EF'
+  - name: broken-link
+    description: Broken links found by automated link checker
+    color: 'd73a4a'
+  - name: techdocs-upstream
+    color: 'ededed'
+  # Assessment workflow labels
+  - name: needs-triage
+    description: Assessment request awaiting triage
+    color: 'EDEDED'
+  - name: triage/accepted
+    description: Assessment request accepted
+    color: 'C2E0C6'
+  - name: triage/declined
+    description: Assessment request declined, reason posted
+    color: 'F9D0C4'
+  - name: phase/assessment
+    description: 'Assessment phase A: analysis'
+    color: 'C5DEF5'
+  - name: phase/implementation
+    description: 'Assessment phase B: implementation plan'
+    color: '84B6EB'
+  - name: phase/backlog
+    description: 'Assessment phase C: issue backlog'
+    color: '1D76DB'
+  - name: verified
+    description: Verification complete for this deliverable PR
+    color: '0E8A16'
+  - name: confirmed
+    description: Stakeholder confirmation recorded for this deliverable PR
+    color: '006B75'
+  - name: skip-implementation
+    description: Phase B skipped; phase A merge opens phase C
+    color: 'D4C5F9'


### PR DESCRIPTION
Adds the nine assessment workflow labels (spec sections 12–13) and fixes
why `.github/settings.yml` has never synced. Spec section 16, step 1.
Tracking: #365. Spec PR: #363. Bound by P-1 and HC-4. Only the `labels:` block changed.

## Root cause

Unquoted colors aren't strings to YAML: `#`-prefixed become comments
(null), all-digit become integers (008672 → 8672), and `89E295` becomes
the float 8.9e+296. That last one is the 2022 commit that never applied,
so every sync failure since shares this cause. Every color is now
quoted.

## Reconciliation (live wins)

A repaired file likely triggers the first real sync on merge, and
declarative sync deletes live labels missing from the file. So the block
now matches live (snapshot 2026-08-14) before adding anything:

- `admin`: duplicates collapsed; live color; file description kept
  (deliberate addition).
- `meta`: removed (in file, not live).
- `suggested doc`: 89E295 → d93f0b (the 2022 change never applied).
- `broken-link`, `techdocs-upstream`: added (live, missing from file).

## New labels

`needs-triage`, `triage/accepted`, `triage/declined`,
`phase/assessment`, `phase/implementation`, `phase/backlog`,
`verified`, `confirmed`, `skip-implementation`.

Names come from the spec; colors and descriptions are review points.

## Verification

- Assertion script: parsed set exactly equals live snapshot plus the
  nine new labels; all colors string-typed six-hex. 36 pass.
- `npm run check` passes.
- Post-merge: expect the first sync since 2022. If nothing applies,
  fallback is by-hand `gh label create`; either path recorded on #365.
