### PR TITLE
[AIAA] Add Copilot cloud agent environment setup workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,26 @@
+# Prepares the Copilot cloud agent's ephemeral environment before the
+# model starts: Node from .nvmrc, npm cache, npm ci. Runs on changes to
+# itself so pull requests validate it; takes effect for agent sessions
+# once merged to the default branch.
+
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job must be called copilot-setup-steps or the agent ignores it.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/npm-ci-via-cached-nvmrc


### PR DESCRIPTION
Adds `.github/workflows/copilot-setup-steps.yml`: prepares the Copilot
cloud agent's ephemeral environment. Build step 4 (spec section 16),
environment per section 11. Tracking: #372.

## What it does

Before the agent's model starts: checkout, Node from `.nvmrc` with npm
cache, `npm ci`, via the repository's existing
`npm-ci-via-cached-nvmrc` composite action. The agent starts with the
toolchain ready to run `npm run check` instead of discovering it.

Minimal on purpose: the deterministic data-collection scripts join
these setup steps in a later build step, once they exist.

## Guardrails

- Setup runs outside the agent's firewall, so this reviewed file is
  the control over what setup fetches (section 11). It fetches only
  the repository and npm dependencies.
- No secrets introduced; `permissions: contents: read` only
  (section 11 secrets policy).
- Single job named `copilot-setup-steps`, the platform's contract;
  `timeout-minutes: 10`, well under the 59-minute session cap.

## Verification

- Assertion script (session artifact): 15 checks pass (job name,
  self-scoped validation triggers, least permissions, exact steps, no
  secrets).
- `npm run check` passes.
- The workflow triggers on changes to itself, so this PR shows a green
  "Copilot Setup Steps" run before merge.
- Post-merge: an agent session's logs showing the prepared environment
  is the done-when; lands with the probe delegation (#366) or the
  first delegated session, recorded on #372.

Contributes to: https://github.com/cncf/techdocs/issues/372